### PR TITLE
Rails 6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-image: ["ruby:2.3", "ruby:2.4", "ruby:2.5", "ruby:2.6"]
+              ruby-image: ["ruby:2.5", "ruby:2.6", "ruby:2.7"]
 
   coveralls:
     jobs:

--- a/lib/stale_options/version.rb
+++ b/lib/stale_options/version.rb
@@ -1,3 +1,3 @@
 module StaleOptions
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/stale_options.gemspec
+++ b/stale_options.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '~> 5.2.0'
-  spec.add_dependency 'activesupport', '~> 5.2.0'
+  spec.add_dependency 'activerecord', '~> 6.0.0'
+  spec.add_dependency 'activesupport', '~> 6.0.0'
 
   spec.add_development_dependency 'minitest', '~> 5.15.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.0'
+  spec.add_development_dependency 'sqlite3', '~> 1.4.0'
 end


### PR DESCRIPTION
Added support for `rails ~> 6.0.0` and `ruby >= 2.5, <= 2.7`.