### PR TITLE
Rails 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-image: ["ruby:2.5", "ruby:2.6", "ruby:2.7"]
+              ruby-image: ["ruby:2.5", "ruby:2.6", "ruby:2.7", "ruby:3.0"]
 
   coveralls:
     jobs:
@@ -34,7 +34,7 @@ jobs:
 
   coveralls:
     docker:
-      - image: "ruby:2.6"
+      - image: "ruby:3.0"
     steps:
       - checkout
       - run:

--- a/lib/stale_options/version.rb
+++ b/lib/stale_options/version.rb
@@ -1,3 +1,3 @@
 module StaleOptions
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/stale_options.gemspec
+++ b/stale_options.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '~> 6.0.0'
-  spec.add_dependency 'activesupport', '~> 6.0.0'
+  spec.add_dependency 'activerecord', '~> 6.1.0'
+  spec.add_dependency 'activesupport', '~> 6.1.0'
 
   spec.add_development_dependency 'minitest', '~> 5.15.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
Added support for `rails ~> 6.1.0` and `ruby >= 2.5, <= 3.0`.