### PR TITLE
Rails 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-image: ["ruby:2.5", "ruby:2.6", "ruby:2.7", "ruby:3.0"]
+              ruby-image: ["ruby:2.7", "ruby:3.0", "ruby:3.1", "ruby:3.2"]
 
   coveralls:
     jobs:

--- a/lib/backend/backend.rb
+++ b/lib/backend/backend.rb
@@ -15,17 +15,17 @@ module StaleOptions
     #  end
     #
     def if_stale?(record, options = {})
-      options = StaleOptions.create(record, options)
+      options = StaleOptions.create(record, **options)
 
-      if stale?(options)
+      if stale?(**options)
         block_given? ? yield(record) : true
       end
     end
 
     def unless_stale?(record, options = {})
-      options = StaleOptions.create(record, options)
+      options = StaleOptions.create(record, **options)
 
-      unless stale?(options)
+      unless stale?(**options)
         block_given? ? yield(record) : true
       end
     end

--- a/lib/stale_options/version.rb
+++ b/lib/stale_options/version.rb
@@ -1,3 +1,3 @@
 module StaleOptions
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/stale_options.gemspec
+++ b/stale_options.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '~> 6.1.0'
-  spec.add_dependency 'activesupport', '~> 6.1.0'
+  spec.add_dependency 'activerecord', '~> 7.0.0'
+  spec.add_dependency 'activesupport', '~> 7.0.0'
 
-  spec.add_development_dependency 'minitest', '~> 5.15.0'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'minitest', '~> 5.18.0'
+  spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', '~> 1.4.0'
+  spec.add_development_dependency 'sqlite3', '~> 1.6.0'
 end

--- a/test/backend/backend_test.rb
+++ b/test/backend/backend_test.rb
@@ -6,7 +6,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, true, [options])
+      mock.expect(:stale?, true, **options)
 
       block_called = false
 
@@ -29,7 +29,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, true, [options])
+      mock.expect(:stale?, true, **options)
 
       class << mock
         include StaleOptions::Backend
@@ -45,7 +45,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, false, [options])
+      mock.expect(:stale?, false, **options)
 
       class << mock
         include StaleOptions::Backend
@@ -64,7 +64,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, false, [options])
+      mock.expect(:stale?, false, **options)
 
       block_called = false
 
@@ -87,7 +87,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, false, [options])
+      mock.expect(:stale?, false, **options)
 
       class << mock
         include StaleOptions::Backend
@@ -103,7 +103,7 @@ class BackendTest < Minitest::Test
 
     StaleOptions.stub :create, options do
       mock = Minitest::Mock.new
-      mock.expect(:stale?, true, [options])
+      mock.expect(:stale?, true, **options)
 
       class << mock
         include StaleOptions::Backend


### PR DESCRIPTION
Added support for `rails ~> 7.0.0` and `ruby >= 2.7, <= 3.2`.